### PR TITLE
Add back gradle.properties

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -18,7 +18,7 @@
 # org.gradle.parallel=true
 
 # Key for signning the app
-# MYAPP_UPLOAD_STORE_FILE=
+MYAPP_UPLOAD_STORE_FILE=daostack_key.jks
 # MYAPP_UPLOAD_KEY_ALIAS=
 # MYAPP_UPLOAD_STORE_PASSWORD=
 # MYAPP_UPLOAD_KEY_PASSWORD=


### PR DESCRIPTION
In the past we removed `gradle.properties` due to keys exposure.
However, there are important configs in that file (the memory issue).

It is better to keep it in the repo without the keys.
To avoid mishandling of keys, I'm leaving it in the git ignore, so that changes will have to be done with caution.