### PR TITLE
CM-1215 In the chat: Allow to copy parts of the text

### DIFF
--- a/src/Screens/Discussions/DiscussionMessage.js
+++ b/src/Screens/Discussions/DiscussionMessage.js
@@ -1,12 +1,11 @@
 import React, {useEffect} from 'react';
-import {StyleSheet, Text, View, Image, Dimensions, Platform} from 'react-native';
+import {StyleSheet, Text, View, Image, Dimensions, Platform, TextInput} from 'react-native';
 import {colors, font} from '~/Theme';
 import auth from '@react-native-firebase/auth';
 import moment from 'moment';
 import {shape, string, object, bool, func} from 'prop-types';
 import Hyperlink from 'react-native-hyperlink';
 import Icon from '../../Assets/iconfont/Icon';
-import {TextInput} from 'react-native-gesture-handler';
 
 const {width} = Dimensions.get('window');
 

--- a/src/Screens/Discussions/Discussions.js
+++ b/src/Screens/Discussions/Discussions.js
@@ -449,7 +449,7 @@ const Discussions = ({daoStore, userStore, bottomSheetStore, navigation,
       >
         <View style={styles.inputContainer}>
           {isMember ? (
-            <View style={[styles.input, {height: Math.max(35, inputHeight)}]}>
+            <View style={[styles.input, {height: Math.max(35, inputHeight + 20)}]}>
               <TextInput
                 ref={inputRef}
                 editable={true}
@@ -465,7 +465,7 @@ const Discussions = ({daoStore, userStore, bottomSheetStore, navigation,
                   maxHeight: 110,
                   paddingVertical: 10,
                   marginHorizontal: 10,
-                  height: Math.max(35, inputHeight),
+                  height: Math.max(35, inputHeight + 10),
                 }}
               />
               <TouchableOpacity

--- a/src/Screens/Proposals/ProposalScreen.js
+++ b/src/Screens/Proposals/ProposalScreen.js
@@ -67,6 +67,7 @@ const ProposalScreen = ({
   const [isSending, setIsSending] = useState(false);
   const [isMember, setIsMember] = useState(false);
   const [isProposer, setIsProposer] = useState(false);
+  const [inputHeight, setInputHeight] = useState(false);
   const [showBottomVotingButtonsContainer, setShowBottomVotingButtonsContainer] = useState(false);
   const renderVoting =
     proposalScreenInfo?.proposalInfo &&
@@ -248,13 +249,18 @@ const ProposalScreen = ({
                 ref={inputRef}
                 editable={true}
                 fontSize={15}
+                multiline
                 placeholder="What do you think?"
                 onChangeText={(currText) => setInputText(currText)}
+                onContentSizeChange={(event) => {
+                  setInputHeight(event.nativeEvent.contentSize.height);
+                }}
                 style={{
                   flex: 1,
-                  height: 22,
                   padding: 0,
                   marginHorizontal: 10,
+                  maxHeight: 110,
+                  height: Math.max(35, inputHeight + 10),
                 }}
               />
               <TouchableOpacity


### PR DESCRIPTION
Use a <TextInput/> on iOS to allow multiple actions and use a regular <Text/> on Android. That will allow specific word selection on both platforms.

Unfortunately selectable property doesn't work in iOs and we have to do this "workaround"