### PR TITLE
CM-1254-notification for chats[WIP]

### DIFF
--- a/src/Screens/Proposals/ProposalScreen.js
+++ b/src/Screens/Proposals/ProposalScreen.js
@@ -34,7 +34,6 @@ import {db} from '~/Firebase';
 import {string, func, object, shape, oneOfType, number} from 'prop-types';
 import logger from '~/Services/Logger';
 import {LAYOUT_ANIMATION_CONFIG} from '~/Util';
-import DiscussionService from '~/Services/DiscussionService';
 import {
   Placeholder,
   PlaceholderMedia,
@@ -149,9 +148,9 @@ const ProposalScreen = ({
       }
     };
 
-    const getDiscussion = async (proposalId) => {
+    const getDiscussion = async (discussionId) => {
       db.collection('discussion')
-        .doc(proposalId)
+        .doc(discussionId)
         .set({
           title: `${proposalScreenInfo?.proposalInfo.description.title} chat`,
           message: proposalScreenInfo?.proposalInfo.description.description,


### PR DESCRIPTION
This is working fine, but is causing chats to be displayed also in discussions, I suggest adding either a flag to the discussion doc to indicate it's a chat and only render I in chats, or create a seperate collection for chats.

Demo for this in the ticket:
https://daostack1.atlassian.net/jira/software/projects/CM/boards/7?selectedIssue=CM-1254