### PR TITLE
Allow unsupported pod installs

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -72,3 +72,11 @@ target 'common-stg' do
   reactnative
   native
 end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      config.build_settings.delete 'IPHONEOS_DEPLOYMENT_TARGET'
+    end
+  end
+end


### PR DESCRIPTION
This is a hack that will allow unsupported pod dependencies to be installed on the newest version of XCode. As mentioned this is a hack and we need to come up with a better solution for this in the future.