### PR TITLE
Make bottom message not sticky

### DIFF
--- a/src/Screens/Commons/CreateCommon/CreateStep4.js
+++ b/src/Screens/Commons/CreateCommon/CreateStep4.js
@@ -138,15 +138,6 @@ const CreateStep4 = ({
     }
   };
 
-  const changeLaterMessage = (
-    <View style={styles.textContainer}>
-      <Text style={styles.text}>
-        Don't worry, you will be able to make changes to the Common info after
-        it is published.
-      </Text>
-    </View>
-  );
-
   const displayString = () =>
     `${numberFormatter(form[CreateCommonForm.MINIMUM])}${
       CONTRIBUTION[form.contribution]
@@ -188,7 +179,6 @@ const CreateStep4 = ({
       requestStepActionButton={
         <RequestStepActionButton
           title="Publish Common"
-          messageBox={changeLaterMessage}
           formStore={agendaFormStore}
           onPress={() => forgeCommon()}
         />
@@ -258,7 +248,7 @@ const CreateStep4 = ({
                 />
               </TouchableOpacity> */}
           </View>
-          {form[CreateCommonForm.LINKS]?.length ? (
+          {form[CreateCommonForm.LINKS]?.length &&
             form[CreateCommonForm.LINKS].map((x) => (
               <View key={`key_${CreateCommonForm.LINKS}_${x.title}`}>
                 <Text
@@ -277,12 +267,9 @@ const CreateStep4 = ({
                   {x.title}
                 </Text>
               </View>
-            ))
-          ) : (
-            <View />
-          )}
+            ))}
         </>
-        {form[CreateCommonForm.RULES]?.length > 0 ? (
+        {form[CreateCommonForm.RULES]?.length > 0 &&
           form[CreateCommonForm.RULES].map((rule, index) => (
             <View key={`key_${CreateCommonForm.RULES}_${index}`}>
               <Text
@@ -300,10 +287,13 @@ const CreateStep4 = ({
               </View>
               <Text style={styles.textContent}>{rule.value}</Text>
             </View>
-          ))
-        ) : (
-          <View />
-        )}
+          ))}
+        <View style={styles.textContainer}>
+          <Text style={styles.text}>
+            Don't worry, you will be able to make changes to the Common info
+            after it is published.
+          </Text>
+        </View>
       </View>
     </StepDotLayout>
   );
@@ -408,12 +398,13 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     ...font.lineHeight(0),
     color: colors.slate,
-    paddingHorizontal: 2,
+    paddingHorizontal: 5,
   },
   textContainer: {
+    alignSelf: 'center',
     borderRadius: 14,
     backgroundColor: colors.lighterBlue,
-    marginBottom: sizeL,
+    marginTop: sizeL,
     height: 75,
     width: '100%',
     justifyContent: 'center',

--- a/src/Screens/Commons/RequestStepActionButton.js
+++ b/src/Screens/Commons/RequestStepActionButton.js
@@ -4,14 +4,7 @@ import {layout, colors, font} from '~/Theme';
 import {string, func, bool, object} from 'prop-types';
 import {observer} from 'mobx-react';
 
-const RequestStepActionButton = ({
-  hidden,
-  pass,
-  formStore,
-  onPress,
-  title,
-  messageBox = null,
-}) => {
+const RequestStepActionButton = ({hidden, pass, formStore, onPress, title}) => {
   let actionBtnStyle = styles.actionBtnContainer;
 
   if (hidden) {
@@ -23,7 +16,6 @@ const RequestStepActionButton = ({
 
   return (
     <View style={actionBtnStyle}>
-      {messageBox}
       <TouchableOpacity
         style={{
           ...styles.continueButton,


### PR DESCRIPTION
Brio asked for the bottom message (in the last step of creating a common) not to be sticky, and only be visible when we scroll down