### PR TITLE
CM-1018 - display link title and not link

### DIFF
--- a/src/Screens/Commons/Profile/CommonAgenda.js
+++ b/src/Screens/Commons/Profile/CommonAgenda.js
@@ -88,7 +88,7 @@ const CommonAgenda = ({
                       })
                     }>
                     {/* NOTE: value of multiple fields was stored in url prop before */}
-                    {link.value || link.url}
+                    {link.title}
                   </Text>
                 </View>
               ))}


### PR DESCRIPTION
This was fixed already before, but somehow got overridden 