### PR TITLE
CM-1590 - app crashes when join 0 contribution common

### DIFF
--- a/src/Components/Commons/JoinAmount.tsx
+++ b/src/Components/Commons/JoinAmount.tsx
@@ -35,7 +35,7 @@ const JoinAmount: React.FC<InferProps<typeof props>> = ({
       <Text style={isSelected ? styles.amountSelected : styles.amount}>{`${
         isCustom ? 'Other' : `$${amount}${isMonthly ? '/mo' : ''}`
       }`}</Text>
-      {amount && !isCustom && isIsraelLocale && (
+      {!!amount && !isCustom && isIsraelLocale && (
         <Text
           style={isSelected ? styles.conversionSelected : styles.conversion}>
           {convertAmountToIls(amount, conversionRate)}


### PR DESCRIPTION
Ticket: https://daostack1.atlassian.net/browse/CM-1590?atlOrigin=eyJpIjoiNTVhZjI3ZWYwNTUxNDBlMDlhNTQ3MTI0M2NkNDQxMGQiLCJwIjoiaiJ9

When `amount` is 0 (for 0 contribution commons) the condition that rendered the text translates to `0` instead of `false` (0 && boolean = 0 so then `0 && <Text>` causes the crash), so added `!!` to strictly convert 0 to boolean 