### PR TITLE
Make link encoding optional - URGENT

### DIFF
--- a/src/Util/index.js
+++ b/src/Util/index.js
@@ -101,7 +101,7 @@ export const formatCurrency = (amount) => {
 };
 
 export const escapeUrl = (linkArr) =>
-  linkArr.map((link) => {
+  linkArr?.map((link) => {
         link.value = encodeURI(link.value);
         return link;
       }


### PR DESCRIPTION
In creating a common, we encode the links, but when there are no links, we get an error
![Screen Shot 2021-02-11 at 5 53 30](https://user-images.githubusercontent.com/30501647/107627580-807dfa80-6c2d-11eb-98bf-3e980f3ee379.png)
