### PR TITLE
CM-290 - fix reporting crash

### DIFF
--- a/src/Components/Notifications/DiscussionMessageReported.tsx
+++ b/src/Components/Notifications/DiscussionMessageReported.tsx
@@ -35,18 +35,17 @@ const DiscussionMessageReported: React.FC<InferProps<typeof props>> = ({
   );
 
   if (messageReportedData) {
-    const {moderation} = messageReportedData;
     const objectData = rootStore.notificationStore.getParentDiscussion(
       messageReportedData,
     );
 
     if (objectData) {
       const common = rootStore.commonStore.getCommonById(objectData.commonId);
-      const reporter = rootStore.userStore.getUserById(moderation.reporter);
+      const messageOwner = rootStore.userStore.getUserById(messageReportedData.ownerId);
       notificationData = {
         missingData: false,
         description: 'A comment was reported',
-        ownerAvatar: reporter.photoURL,
+        ownerAvatar: messageOwner.photoURL,
         common,
         ...getParentObject(objectData),
       };

--- a/src/Components/Notifications/ProposalReported.tsx
+++ b/src/Components/Notifications/ProposalReported.tsx
@@ -23,8 +23,8 @@ const ProposalReported: React.FC<InferProps<typeof props>> = ({
   let eventType = item.eventType;
   const proposal = rootStore.proposalStore.getProposalById(item.eventObjectId);
   if (proposal) {
-    const reporter = rootStore.userStore.getUserById(
-      proposal.moderation.reporter,
+    const proposer = rootStore.userStore.getUserById(
+      proposal.proposerId,
     );
     const isJoin = proposal.type === PROPOSAL_TYPE.Join;
 
@@ -39,7 +39,7 @@ const ProposalReported: React.FC<InferProps<typeof props>> = ({
         description: `A ${
           isJoin ? 'membership request' : 'proposal'
         } was reported`,
-        ownerAvatar: reporter.photoURL,
+        ownerAvatar: proposer.photoURL,
         common,
       };
     }

--- a/src/Screens/Discussions/DiscussionMessage.js
+++ b/src/Screens/Discussions/DiscussionMessage.js
@@ -77,7 +77,7 @@ const DiscussionMessage = ({
 
   const flagView = (isModerator || isHidden) && isFlagged && (
     <View style={{flexDirection: 'row', marginLeft: 30}}>
-      <Icon name={'hidden'} style={layout.marginRightS} color={colors.grey3} />
+      {isHidden && <Icon name={'hidden'} style={layout.marginRightS} color={colors.grey3} />}
       <Text style={{...styles.hiddenTitle, color: colors.grey3}}>
         {_.upperFirst(flag)}
         {isHidden && !isModerator ? '' : ` by ${moderatorName}`}


### PR DESCRIPTION
This was also happening for proposals:
we were getting the message/proposal from the store, and since they already existed, we got it from there, without the update of the moderation field, which resulted in `moderation` being undefined.

I spoke with Tai, he said we should have the `owner` of the message/proposal instead of the reported (this is how it's done for discussions), so this is the change I added.

(also removed the `hidden` icon for the content is only `reported`