### PR TITLE
CM-245-Fix text covering post's  back arrow

### DIFF
--- a/src/Screens/Discussions/Discussions.js
+++ b/src/Screens/Discussions/Discussions.js
@@ -217,7 +217,7 @@ const Discussions = ({
         }}
         title={{
           title: dataState.title,
-          style: text.h2Black,
+          style: {...text.h2Black, maxWidth: '70%'},
           ellipsizeMode: 'tail',
           numberOfLines: 1,
         }}


### PR DESCRIPTION
Ticket with screenshot:
https://github.com/daostack/common-monorepo/issues/245