### PR TITLE
CM-320-remove elevation for other's comment

### DIFF
--- a/src/Screens/Discussions/DiscussionMessage.js
+++ b/src/Screens/Discussions/DiscussionMessage.js
@@ -108,6 +108,7 @@ const DiscussionMessage = ({
               ...styles.contentOwner,
               backgroundColor: isHidden ? colors.paleLilacTwo : colors.white,
               alignItems: isHidden ? 'flex-start' : 'flex-end',
+              elevation: 2,
             }}>
             {flagView}
             {(!isHidden || viewerPermission) && (
@@ -258,7 +259,6 @@ const styles = StyleSheet.create({
     },
     shadowRadius: 4,
     shadowOpacity: 0.2,
-    elevation: 2,
   },
   contentMember: {
     flexDirection: 'row',


### PR DESCRIPTION
removed elevation from `contentOwner` because it caused the comment to look like this:
<img width="282" alt="Screen Shot 2021-04-06 at 12 12 11" src="https://user-images.githubusercontent.com/30501647/113743542-c73e1d00-96d1-11eb-8b05-bdd1dceacd7c.png">
