### PR TITLE
The app crashes when user clicks on "Leave without saving" button #342

### DIFF
--- a/src/Screens/BottomSheetScreens/SortProposals.js
+++ b/src/Screens/BottomSheetScreens/SortProposals.js
@@ -13,7 +13,7 @@ import {object, func} from 'prop-types';
 
 const SortProposals = ({navigation, onContinueEditing}) => {
   const liveWithoutSave = (e) => {
-    navigation?.current?.goBack();
+    navigation?.current.goBack();
   };
 
   const continueEditing = (e) => {

--- a/src/Screens/BottomSheetScreens/UnsavedChanges.js
+++ b/src/Screens/BottomSheetScreens/UnsavedChanges.js
@@ -18,7 +18,7 @@ const UnsavedChanges = ({
 }) => {
   const liveWithoutSave = (e) => {
     if (navigation?.current) {
-      navigation?.current?.goBack();
+      navigation?.current.goBack();
       if (onLeaveWithoutSaving) {
         onLeaveWithoutSaving();
       }


### PR DESCRIPTION
Replace `navigation.goBack` with `navigation.current.goBack()`, because previously I added `React.cloneElement` to **ALL** bottomSheet pop ups and it replaced `navigation` prop and `my navigation is a navigationRef`
<img width="594" alt="Screenshot 2021-04-08 at 12 11 44" src="https://user-images.githubusercontent.com/35873164/114000345-97268380-9863-11eb-9cf3-8316d2ad56e7.png">
