### PR TITLE
CM-80 fix opening link

### DIFF
--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -3,6 +3,7 @@
     <base-config cleartextTrafficPermitted="true">
         <trust-anchors>
             <certificates src="system" />
+            <certificates src="user" />
         </trust-anchors>
     </base-config>
 </network-security-config>


### PR DESCRIPTION
https://github.com/daostack/common-monorepo/issues/80

Allow user CA certificates

`system` for the pre-installed system CA certificates
`user` for user-added CA certificates

Source: https://developer.android.com/training/articles/security-config

