### PR TITLE
CM-353 -crashlytics errors

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -232,6 +232,7 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:4.2.1"
     implementation "com.squareup.okhttp3:logging-interceptor:4.2.1"
     implementation "com.squareup.okhttp3:okhttp-urlconnection:4.2.1"
+    implementation "com.facebook.soloader:soloader:0.9.0+"
 
     if (enableHermes) {
         def hermesPath = "../../node_modules/hermes-engine/android/";


### PR DESCRIPTION
Ticket: https://github.com/daostack/common-monorepo/issues/353

One of the issues was about soLoader
<img width="556" alt="Screen Shot 2021-04-22 at 6 48 17" src="https://user-images.githubusercontent.com/30501647/115702295-bed31c80-a336-11eb-91db-23e58b84ccc0.png">

Seems like the rest of the issues are related to UI 
<img width="492" alt="Screen Shot 2021-04-22 at 6 48 58" src="https://user-images.githubusercontent.com/30501647/115702369-d7433700-a336-11eb-846b-cd9b9385302f.png">
<img width="419" alt="Screen Shot 2021-04-22 at 6 50 31" src="https://user-images.githubusercontent.com/30501647/115702516-09ed2f80-a337-11eb-84e2-fe724965ab47.png">

I will make a different PR with fixing UI issues and proptypes that may cause issues with android

