### PR TITLE
CM-517 - hide countdown when proposal is rejected

### DIFF
--- a/src/Components/MemberCard.js
+++ b/src/Components/MemberCard.js
@@ -6,7 +6,7 @@ import MemberImage from './Commons/MemberImage';
 import CountDown from 'react-native-countdown-component';
 import {monthShortNames} from '~/Util/DateUtil';
 import moment from 'moment';
-import {LAUNCHED_STATES} from '~/Services/ProposalService';
+import {LAUNCHED_STATES, COUNTDOWN_STATES} from '~/Services/ProposalService';
 import {string, array, number, shape, object, oneOfType} from 'prop-types';
 import {rootStorePropTypes} from '~/Types/propTypes';
 import {PERMISSIONS} from '~/Util/constants/permissions.enum';
@@ -46,6 +46,7 @@ const MemberCard = ({
             {/* Hide the time if the proposal is expired or new */}
             {remainingSeconds > 0 &&
               !LAUNCHED_STATES.includes(proposalInfo?.state) &&
+              !COUNTDOWN_STATES.includes(proposalInfo?.state) &&
               // If the remaining time is more than 1 day show the date,
               // if it is less show countdown till it
               (remainingSeconds > 24 * 60 * 60 ? (

--- a/src/Components/Moderation/Report.tsx
+++ b/src/Components/Moderation/Report.tsx
@@ -125,7 +125,7 @@ const Report: React.FC<InferProps<typeof reportProps>> = ({
               formStore.getFormField(ModerationForm.MODERATOR_NOTE, false)
                 ?.value
             }
-            onChangeText={(noteText: string) =>  isValidNote(noteText)}
+            onChangeText={(noteText: string) => isValidNote(noteText)}
             validation={{
               name: 'moderatorNote',
               formStore: formStore,


### PR DESCRIPTION
Ticket: https://github.com/daostack/common-monorepo/issues/517

Basically, when rejecting a proposal, it was still showing the countdown running

demo to how it was before the fix:
https://user-images.githubusercontent.com/30501647/119268736-fb778980-bbfc-11eb-9683-4ece7e5f0728.mov


After this fix:
<img width="316" alt="Screen Shot 2021-05-23 at 19 23 28" src="https://user-images.githubusercontent.com/30501647/119268755-06cab500-bbfd-11eb-8c42-9a14b8a57799.png">
<img width="323" alt="Screen Shot 2021-05-23 at 19 23 21" src="https://user-images.githubusercontent.com/30501647/119268756-07634b80-bbfd-11eb-80a4-bb4b4eb1af40.png">
