### PR TITLE
CM-1037 Contribution conflict

### DIFF
--- a/src/Screens/Commons/CreateCommon/CreateStep2.js
+++ b/src/Screens/Commons/CreateCommon/CreateStep2.js
@@ -13,7 +13,7 @@ import {CurrencySymbols} from '~/Util/locale';
 import {Bold} from '~/Components/Text/Bold';
 
 const CONTRIBUTION_TAB_VALUES = ['one-time', 'monthly'];
-const MAX_CONTRIBUTION = '2000';
+const MAX_CONTRIBUTION = '500';
 const MIN_CONTRIBUTION = '10';
 
 const CreateStep2 = ({


### PR DESCRIPTION
Since we changed $ to ₪, max min contribution amount changed from 500$ to 2500₪. That caused conflict with the contribution amount options on membership request flow. Now it's decided make it again 500₪.
https://github.com/daostack/common-monorepo/issues/1037