### PR TITLE
Production - common - app crashes when opening common with many members #1127

### DIFF
--- a/src/Screens/Commons/Profile/CommonProfile.js
+++ b/src/Screens/Commons/Profile/CommonProfile.js
@@ -395,7 +395,7 @@ const CommonProfile = ({navigation, route: {params}, rootStore}) => {
             </View>
             <View style={{...layout.flexRow, ...layout.marginLeftS}}>
               <Text style={text.h4BlackRegular}>
-                {`${pendingProposalsData.pendingProposalCount}  Pending`}
+                {`${pendingProposalsData?.pendingProposalCount ?? 0}  Pending`}
               </Text>
               <Icon name="right-arrow" />
             </View>


### PR DESCRIPTION
https://github.com/daostack/common-backend/issues/1127

Probably the application crashes because of `pendingProposalsData.pendingProposalCount` . I also cannot to reproduce the bug on the emulator